### PR TITLE
TCIOS-812173 Non TC Flow | Add name field validation & error codes for failure cases

### DIFF
--- a/TrueSDK/Core/TCError.h
+++ b/TrueSDK/Core/TCError.h
@@ -27,7 +27,8 @@
  * @constant TCTrueSDKErrorCodeBadRequest Bad request. Internal error.
  * @constant TCTrueSDKErrorCodeVerificationFailed The response signature could not be verified. Internal error.
  * @constant TCTrueSDKErrorCodeRequestNonceMismatch The request's nonce does not match the nonce in response. Internal error.
- * @constant TCTrueSDKErrorCodeAppLinkMissing View delegate is Nil or not set
+ * @constant TCTrueSDKErrorCodeViewDelegateNil View delegate is Nil or not set
+ * @constant TCTrueSDKErrorCodeInvalidName Please provide a valid name
  */
 
 typedef NS_ENUM(NSUInteger, TCTrueSDKErrorCode) {
@@ -48,6 +49,7 @@ typedef NS_ENUM(NSUInteger, TCTrueSDKErrorCode) {
     TCTrueSDKErrorCodeVerificationFailed, //
     TCTrueSDKErrorCodeRequestNonceMismatch, //
     TCTrueSDKErrorCodeViewDelegateNil, //
+    TCTrueSDKErrorCodeInvalidName, //
 };
 
 /*!

--- a/TrueSDK/Core/TCError.m
+++ b/TrueSDK/Core/TCError.m
@@ -67,6 +67,9 @@
         case TCTrueSDKErrorCodeViewDelegateNil:
             errorDescription = @"View delegate is nil. You have to set a view delegate";
             break;
+        case TCTrueSDKErrorCodeInvalidName:
+            errorDescription = @"Please provide a valid name";
+            break;
         default:
             break;
     }

--- a/TrueSDK/External/TCTrueSDK.m
+++ b/TrueSDK/External/TCTrueSDK.m
@@ -275,6 +275,12 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
     _firstName = firstName;
     _lastName = lastName;
     
+    if (![self isValidInput]) {
+        TCError *error = [TCError errorWithCode:TCTrueSDKErrorCodeInvalidName];
+        [self.delegate didFailToReceiveTrueProfileWithError:error];
+        return;
+    }
+    
     TCVerifyCodeRequest *request = [[TCVerifyCodeRequest alloc] initWithappKey:self.appKey appLink:self.appLink];
     [request verifyLoginCodeForPhoneNumber:_phone
                                countryCode:_countryCode
@@ -293,6 +299,21 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
             [_delegate didFailToReceiveTrueProfileWithError: [TCError errorWithCode:TCTrueSDKErrorCodeInternal description:error.localizedDescription]];
         }
     }];
+}
+
+- (BOOL)isValidInput {
+    if ((self.firstName.length == 0) ||
+        (self.firstName.length > 124) ||
+        (self.lastName.length > 124) ||
+        [self doesStringContainOnlyNumbers:self.firstName]) {
+        return false;
+    }
+    return true;
+}
+
+-(BOOL)doesStringContainOnlyNumbers: (NSString *)string {
+    NSCharacterSet *nonDigits = [NSCharacterSet decimalDigitCharacterSet].invertedSet;
+    return ([string rangeOfCharacterFromSet:nonDigits].location == NSNotFound);
 }
 
 - (void)updateProfileDetails: (TCLoginCodeResponse *)response {

--- a/TrueSDK/External/TCTrueSDK.m
+++ b/TrueSDK/External/TCTrueSDK.m
@@ -303,8 +303,8 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
 
 - (BOOL)isValidInput {
     if ((self.firstName.length == 0) ||
-        (self.firstName.length > 124) ||
-        (self.lastName.length > 124) ||
+        (self.firstName.length > 128) ||
+        (self.lastName.length > 128) ||
         [self doesStringContainOnlyNumbers:self.firstName]) {
         return false;
     }

--- a/TrueSDK/External/TCTrueSDK.m
+++ b/TrueSDK/External/TCTrueSDK.m
@@ -34,6 +34,7 @@ NSString *const kTCTruecallerAppURL = @"https://www.truecaller.com/userProfile";
 
 @property (nonatomic, strong) NSString *firstName;
 @property (nonatomic, strong) NSString *lastName;
+@property (nonatomic, strong) DisclaimerView *disclaimerView;
 
 @end
 
@@ -202,18 +203,18 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
     
     NSInteger bottomPadding = 0;
     
-    UIView *view = [[DisclaimerView alloc] init];
-    [view setBackgroundColor:[UIColor colorWithWhite:0 alpha:0.33]];
-    view.translatesAutoresizingMaskIntoConstraints = NO;
-    view.clipsToBounds = YES;
-    [controller.view addSubview:view];
+    self.disclaimerView = [[DisclaimerView alloc] init];
+    [self.disclaimerView setBackgroundColor:[UIColor colorWithWhite:0 alpha:0.33]];
+    self.disclaimerView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.disclaimerView.clipsToBounds = YES;
+    [controller.view addSubview:self.disclaimerView];
     
-    [view.leftAnchor constraintEqualToAnchor:controller.view.leftAnchor].active = YES;
-    [view.rightAnchor constraintEqualToAnchor:controller.view.rightAnchor].active = YES;
+    [self.disclaimerView.leftAnchor constraintEqualToAnchor:controller.view.leftAnchor].active = YES;
+    [self.disclaimerView.rightAnchor constraintEqualToAnchor:controller.view.rightAnchor].active = YES;
     if (@available(iOS 11.0, *)) {
-        [view.bottomAnchor constraintEqualToAnchor:controller.view.safeAreaLayoutGuide.bottomAnchor constant:bottomPadding].active = YES;
+        [self.disclaimerView.bottomAnchor constraintEqualToAnchor:controller.view.safeAreaLayoutGuide.bottomAnchor constant:bottomPadding].active = YES;
     } else {
-        [view.bottomAnchor constraintEqualToAnchor:controller.view.bottomAnchor constant:bottomPadding].active = YES;
+        [self.disclaimerView.bottomAnchor constraintEqualToAnchor:controller.view.bottomAnchor constant:bottomPadding].active = YES;
     }
 }
 
@@ -243,6 +244,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
                     [self getProfileForResponse:response];
                     [_delegate verificationStatusChangedTo:TCVerificationStateVerifiedBefore];
                 }
+                [self hideDisclaimer];
             } else {
                 TCLog(@"Non truecaller flow - Request OTP error");
                 [_delegate didFailToReceiveTrueProfileWithError: [TCError errorWithCode:TCTrueSDKErrorCodeInternal description:error.localizedDescription]];
@@ -310,4 +312,9 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
     return  _loginCodeResponse.tokenTtl;
 }
 
+- (void)hideDisclaimer {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.disclaimerView.hidden = YES;
+    });
+}
 @end

--- a/TrueSDK/External/TCTrueSDK.m
+++ b/TrueSDK/External/TCTrueSDK.m
@@ -245,7 +245,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
                 }
             } else {
                 TCLog(@"Non truecaller flow - Request OTP error");
-                [_delegate didFailToReceiveTrueProfileWithError: [TCError errorWithError:error]];
+                [_delegate didFailToReceiveTrueProfileWithError: [TCError errorWithCode:TCTrueSDKErrorCodeInternal description:error.localizedDescription]];
             }
         }];
 }
@@ -262,7 +262,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
             [self.delegate didReceiveTrueProfile:profile];
         } else {
             TCLog(@"Non truecaller flow - Get profile Error");
-            [_delegate didFailToReceiveTrueProfileWithError: [TCError errorWithError:error]];
+            [_delegate didFailToReceiveTrueProfileWithError: [TCError errorWithCode:TCTrueSDKErrorCodeInternal description:error.localizedDescription]];
         }
     }];
 }
@@ -288,7 +288,7 @@ continueUserActivity:(nonnull NSUserActivity *)userActivity
             }
         } else {
             TCLog(@"Non truecaller flow - Verification OTP Error");
-            [_delegate didFailToReceiveTrueProfileWithError: [TCError errorWithError:error]];
+            [_delegate didFailToReceiveTrueProfileWithError: [TCError errorWithCode:TCTrueSDKErrorCodeInternal description:error.localizedDescription]];
         }
     }];
 }


### PR DESCRIPTION
Name validation based on QA comment:-
- FirstName can contain alphabets, alphanumeric characters up to 128 characters but never be blank or can never contain only digits.
- LastName can also contain the same characters up to 128 characters but is optional.

Api error from server used to contain very long error code, so for all API error the error code passed from sdk will be 10 i.e TCTrueSDKErrorCodeInternal, along with the specific error message from backend